### PR TITLE
Initialize TypeScript Expo + Express structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-# dvicx
+# Digital Vehicle Inspection App
+
+This repository contains the boilerplate for a mobile-first DVI app built with React Native (Expo) and a Node.js (Express) API, both written in TypeScript.
+
+- `frontend/` – Expo project
+- `backend/` – Express API
+
+Each subproject has its own README with setup instructions.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,3 @@
+PORT=3000
+DB_URL=postgres://user:password@localhost:5432/dvicx
+JWT_SECRET=your_jwt_secret

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,12 @@
+# Backend
+
+Express API written in TypeScript. Provides services for the Digital Vehicle Inspection application.
+
+## Setup
+
+```bash
+npm install
+npm run dev
+```
+
+Environment variables can be configured in `.env`.

--- a/backend/controllers/index.ts
+++ b/backend/controllers/index.ts
@@ -1,0 +1,1 @@
+// TODO: implement controllers

--- a/backend/database/index.ts
+++ b/backend/database/index.ts
@@ -1,0 +1,1 @@
+// TODO: Implement SQL Server connection

--- a/backend/models/index.ts
+++ b/backend/models/index.ts
@@ -1,0 +1,1 @@
+// TODO: implement models

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "dvicx-backend",
+  "version": "1.0.0",
+  "main": "dist/server.js",
+  "scripts": {
+    "dev": "ts-node-dev server.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/backend/routes/index.ts
+++ b/backend/routes/index.ts
@@ -1,0 +1,1 @@
+// TODO: implement routes

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -1,0 +1,11 @@
+import express from 'express';
+import routes from './routes';
+
+const app = express();
+app.use(express.json());
+app.use('/api', routes); // TODO: secure routes with authentication
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/backend/services/index.ts
+++ b/backend/services/index.ts
@@ -1,0 +1,1 @@
+// TODO: implement services

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+API_URL=http://localhost:3000

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+// TODO: Add navigation container and theme setup
+
+export default function App() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Digital Vehicle Inspection</Text>
+      {/* Mechanic login screen will be added here */}
+    </View>
+  );
+}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,13 @@
+# Frontend
+
+React Native app using Expo in TypeScript.
+
+## Setup
+
+```bash
+npm install -g expo-cli
+npm install
+expo start
+```
+
+Environment variables can be configured in `.env`.

--- a/frontend/components/index.ts
+++ b/frontend/components/index.ts
@@ -1,0 +1,1 @@
+// TODO: export components

--- a/frontend/contexts/index.ts
+++ b/frontend/contexts/index.ts
@@ -1,0 +1,1 @@
+// TODO: export contexts

--- a/frontend/hooks/index.ts
+++ b/frontend/hooks/index.ts
@@ -1,0 +1,1 @@
+// TODO: export hooks

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "dvicx-frontend",
+  "version": "1.0.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start"
+  },
+  "dependencies": {
+    "expo": "^49.0.0",
+    "react": "18.x",
+    "react-native": "0.72.x"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/frontend/screens/index.ts
+++ b/frontend/screens/index.ts
@@ -1,0 +1,1 @@
+// TODO: export screens

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "esnext",
+    "jsx": "react",
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "node",
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/frontend/utils/index.ts
+++ b/frontend/utils/index.ts
@@ -1,0 +1,1 @@
+// TODO: export utils


### PR DESCRIPTION
## Summary
- scaffold a React Native Expo front-end
- scaffold an Express API back-end
- add placeholder comments for future implementation

## Testing
- `npx -y tsc --project backend/tsconfig.json` *(fails: Cannot find module 'express')*
- `npx -y tsc --project frontend/tsconfig.json` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6850b2f645fc832fbafa3c4274beea3e