### PR TITLE
Add mechanic login screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+**/node_modules
+frontend/package-lock.json

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { View, Text } from 'react-native';
-// TODO: Add navigation container and theme setup
+import { AuthProvider } from './contexts';
+import { LoginScreen } from './screens';
 
 export default function App() {
   return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Text>Digital Vehicle Inspection</Text>
-      {/* Mechanic login screen will be added here */}
-    </View>
+    <AuthProvider>
+      <LoginScreen />
+    </AuthProvider>
   );
 }

--- a/frontend/components/Button.tsx
+++ b/frontend/components/Button.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { TouchableOpacity, Text, StyleSheet, ActivityIndicator, ViewStyle } from 'react-native';
+
+interface Props {
+  title: string;
+  onPress: () => void;
+  loading?: boolean;
+  style?: ViewStyle;
+}
+
+export default function Button({ title, onPress, loading, style }: Props) {
+  return (
+    <TouchableOpacity style={[styles.button, style]} onPress={onPress} disabled={loading}>
+      {loading ? <ActivityIndicator color="#fff" /> : <Text style={styles.text}>{title}</Text>}
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    backgroundColor: '#ff00ff',
+    paddingVertical: 12,
+    alignItems: 'center',
+    borderRadius: 4,
+  },
+  text: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+});

--- a/frontend/components/TextInput.tsx
+++ b/frontend/components/TextInput.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { TextInput as RNTextInput, TextInputProps, StyleSheet } from 'react-native';
+
+export default function TextInput(props: TextInputProps) {
+  return <RNTextInput placeholderTextColor="#666" style={styles.input} {...props} />;
+}
+
+const styles = StyleSheet.create({
+  input: {
+    backgroundColor: '#fff',
+    color: '#000',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderRadius: 4,
+    marginBottom: 12,
+  },
+});

--- a/frontend/components/index.ts
+++ b/frontend/components/index.ts
@@ -1,1 +1,2 @@
-// TODO: export components
+export { default as TextInput } from './TextInput';
+export { default as Button } from './Button';

--- a/frontend/contexts/AuthContext.tsx
+++ b/frontend/contexts/AuthContext.tsx
@@ -1,0 +1,36 @@
+import React, { createContext, useState, ReactNode } from 'react';
+
+interface AuthContextProps {
+  mechanicId: string | null;
+  token: string | null;
+  login: (mechanicId: string, token: string) => void;
+  logout: () => void;
+}
+
+export const AuthContext = createContext<AuthContextProps>({
+  mechanicId: null,
+  token: null,
+  login: () => {},
+  logout: () => {}
+});
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [mechanicId, setMechanicId] = useState<string | null>(null);
+  const [token, setToken] = useState<string | null>(null);
+
+  const login = (id: string, authToken: string) => {
+    setMechanicId(id);
+    setToken(authToken);
+  };
+
+  const logout = () => {
+    setMechanicId(null);
+    setToken(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ mechanicId, token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/frontend/contexts/index.ts
+++ b/frontend/contexts/index.ts
@@ -1,1 +1,1 @@
-// TODO: export contexts
+export * from './AuthContext';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
   "dependencies": {
     "expo": "^49.0.0",
     "react": "18.x",
-    "react-native": "0.72.x"
+    "react-native": "0.72.x",
+    "axios": "^1.6.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/frontend/screens/LoginScreen.tsx
+++ b/frontend/screens/LoginScreen.tsx
@@ -1,0 +1,75 @@
+import React, { useState, useContext } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { TextInput, Button } from '../components';
+import api from '../services/api';
+import { AuthContext } from '../contexts';
+
+export default function LoginScreen() {
+  const { login } = useContext(AuthContext);
+  const [mechanicId, setMechanicId] = useState('');
+  const [pin, setPin] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    if (!mechanicId && !pin) {
+      setError('Please enter Mechanic ID or PIN');
+      return;
+    }
+    setError(null);
+    setLoading(true);
+    try {
+      const response = await api.post('/mechanic/login', { mechanicId, pin });
+      const { token, mechanicId: id } = response.data;
+      login(id, token);
+    } catch (err: any) {
+      setError('Invalid credentials');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Mechanic Login</Text>
+      <TextInput
+        placeholder="Mechanic ID"
+        value={mechanicId}
+        onChangeText={setMechanicId}
+        autoCapitalize="none"
+      />
+      <TextInput
+        placeholder="PIN"
+        value={pin}
+        onChangeText={setPin}
+        secureTextEntry
+      />
+      {error && <Text style={styles.error}>{error}</Text>}
+      <Button title="Login" onPress={handleSubmit} loading={loading} style={styles.button} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#2b2b2b',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  title: {
+    color: '#fff',
+    fontSize: 24,
+    fontWeight: '600',
+    textAlign: 'center',
+    marginBottom: 24,
+  },
+  error: {
+    color: '#ff6b6b',
+    marginBottom: 12,
+    textAlign: 'center',
+  },
+  button: {
+    marginTop: 12,
+  },
+});

--- a/frontend/screens/index.ts
+++ b/frontend/screens/index.ts
@@ -1,1 +1,1 @@
-// TODO: export screens
+export { default as LoginScreen } from './LoginScreen';

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+const api = axios.create({
+  baseURL: process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3000/api',
+});
+
+export default api;


### PR DESCRIPTION
## Summary
- implement Klipboard styled `LoginScreen`
- create custom `TextInput` and `Button`
- add `AuthContext` for login state
- configure Axios API service
- wire login screen into the app
- ignore node modules in `.gitignore`

## Testing
- `npm install --prefix frontend`
- `npx tsc -p frontend/tsconfig.json` *(fails: duplicate identifier errors)*

------
https://chatgpt.com/codex/tasks/task_e_6850b3f09330832f873c10bbf9a5c48b