### PR TITLE
Add work orders list screen

### DIFF
--- a/backend/controllers/workOrderController.ts
+++ b/backend/controllers/workOrderController.ts
@@ -1,0 +1,18 @@
+import { Request, Response } from 'express';
+import * as workOrderService from '../services/workOrderService';
+
+export async function getWorkOrders(req: Request, res: Response): Promise<void> {
+  const mechanicId = parseInt(req.params.mechanicId || req.query.mechanicId as string, 10);
+  if (!mechanicId) {
+    res.status(400).json({ message: 'mechanicId required' });
+    return;
+  }
+
+  try {
+    const orders = await workOrderService.findByTechId(mechanicId);
+    res.json(orders);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: 'Server error' });
+  }
+}

--- a/backend/models/workOrderModel.ts
+++ b/backend/models/workOrderModel.ts
@@ -1,0 +1,10 @@
+export interface WorkOrder {
+  estimateNo: number;
+  techId: number;
+  vehYear: string;
+  vehMake: string;
+  vehModel: string;
+  license: string;
+  date: Date;
+  status: string;
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@types/express": "^5.0.3",
     "@types/mssql": "^9.1.7",
+    "@types/node": "^24.0.3",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.0.0"
   }

--- a/backend/routes/index.ts
+++ b/backend/routes/index.ts
@@ -1,9 +1,11 @@
 import { Router } from 'express';
 import authRoutes from './auth';
+import workOrderRoutes from './workOrders';
 
 const router = Router();
 
 router.use('/auth', authRoutes);
+router.use('/workorders', workOrderRoutes);
 
 export default router;
 

--- a/backend/routes/workOrders.ts
+++ b/backend/routes/workOrders.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { getWorkOrders } from '../controllers/workOrderController';
+
+const router = Router();
+
+router.get('/:mechanicId', getWorkOrders);
+
+export default router;

--- a/backend/services/workOrderService.ts
+++ b/backend/services/workOrderService.ts
@@ -1,0 +1,23 @@
+import { sql, poolPromise } from '../database/sql';
+import { WorkOrder } from '../models/workOrderModel';
+
+export async function findByTechId(techId: number): Promise<WorkOrder[]> {
+  const pool = await poolPromise;
+  const result = await pool
+    .request()
+    .input('TechID', sql.Int, techId)
+    .query(
+      `SELECT ESTIMATE_NO, TECH_ID, VEH_YEAR, VEH_MAKE, VEH_MODEL, LICENSE, DATE, STATUS FROM ESTMTEHDR WHERE TECH_ID = @TechID`
+    );
+
+  return result.recordset.map((row: any) => ({
+    estimateNo: row.ESTIMATE_NO,
+    techId: row.TECH_ID,
+    vehYear: row.VEH_YEAR,
+    vehMake: row.VEH_MAKE,
+    vehModel: row.VEH_MODEL,
+    license: row.LICENSE,
+    date: row.DATE,
+    status: row.STATUS,
+  }));
+}

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,11 +1,34 @@
-import React from 'react';
-import { AuthProvider } from './contexts';
-import { LoginScreen } from './screens';
+import React, { useContext } from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { AuthProvider, AuthContext } from './contexts';
+import { LoginScreen, WorkOrdersScreen, InspectionScreen } from './screens';
+
+const Stack = createNativeStackNavigator();
+
+function RootNavigator() {
+  const { mechanicId } = useContext(AuthContext);
+
+  return (
+    <NavigationContainer>
+      <Stack.Navigator screenOptions={{ headerShown: false }}>
+        {mechanicId ? (
+          <>
+            <Stack.Screen name="WorkOrders" component={WorkOrdersScreen} />
+            <Stack.Screen name="Inspection" component={InspectionScreen} />
+          </>
+        ) : (
+          <Stack.Screen name="Login" component={LoginScreen} />
+        )}
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
 
 export default function App() {
   return (
     <AuthProvider>
-      <LoginScreen />
+      <RootNavigator />
     </AuthProvider>
   );
 }

--- a/frontend/components/WorkOrderCard.tsx
+++ b/frontend/components/WorkOrderCard.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, TouchableOpacity, Text, StyleSheet, ViewStyle } from 'react-native';
+
+interface Props {
+  order: {
+    estimateNo: number;
+    vehYear: string;
+    vehMake: string;
+    vehModel: string;
+    license: string;
+    date: string;
+    status: string;
+  };
+  onPress: () => void;
+  style?: ViewStyle;
+}
+
+export default function WorkOrderCard({ order, onPress, style }: Props) {
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.timing(fadeAnim, {
+      toValue: 1,
+      duration: 500,
+      useNativeDriver: true,
+    }).start();
+  }, [fadeAnim]);
+
+  return (
+    <Animated.View style={[styles.card, style, { opacity: fadeAnim }]}> 
+      <TouchableOpacity onPress={onPress}>
+        <Text style={styles.title}>WO #{order.estimateNo}</Text>
+        <Text style={styles.text}>{order.vehYear} {order.vehMake} {order.vehModel}</Text>
+        <Text style={styles.text}>License: {order.license}</Text>
+        <Text style={styles.sub}>{new Date(order.date).toLocaleDateString()} • {order.status}</Text>
+      </TouchableOpacity>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#2b2b2b',
+    padding: 16,
+    borderRadius: 8,
+    marginBottom: 12,
+    shadowColor: '#000',
+    shadowOpacity: 0.3,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 3 },
+  },
+  title: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: '700',
+    marginBottom: 4,
+  },
+  text: {
+    color: '#eaeaea',
+    fontSize: 14,
+  },
+  sub: {
+    color: '#bbbbbb',
+    marginTop: 6,
+    fontSize: 12,
+  },
+});

--- a/frontend/components/index.ts
+++ b/frontend/components/index.ts
@@ -1,2 +1,3 @@
 export { default as TextInput } from './TextInput';
 export { default as Button } from './Button';
+export { default as WorkOrderCard } from './WorkOrderCard';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,12 +6,18 @@
     "start": "expo start"
   },
   "dependencies": {
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12",
+    "axios": "^1.6.0",
     "expo": "^49.0.0",
     "react": "18.x",
     "react-native": "0.72.x",
-    "axios": "^1.6.0"
+    "react-native-safe-area-context": "^4.6.3",
+    "react-native-screens": "~3.22.0"
   },
   "devDependencies": {
+    "@types/react": "^19.1.8",
+    "@types/react-native": "^0.72.8",
     "typescript": "^5.0.0"
   }
 }

--- a/frontend/screens/InspectionScreen.tsx
+++ b/frontend/screens/InspectionScreen.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function InspectionScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>Inspection Screen</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#1c1c1c',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    color: '#fff',
+  },
+});

--- a/frontend/screens/WorkOrdersScreen.tsx
+++ b/frontend/screens/WorkOrdersScreen.tsx
@@ -1,0 +1,75 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { View, FlatList, StyleSheet, ActivityIndicator } from 'react-native';
+import { AuthContext } from '../contexts';
+import { getWorkOrders } from '../services/api';
+import WorkOrderCard from '../components/WorkOrderCard';
+import { useNavigation } from '@react-navigation/native';
+
+interface WorkOrder {
+  estimateNo: number;
+  vehYear: string;
+  vehMake: string;
+  vehModel: string;
+  license: string;
+  date: string;
+  status: string;
+}
+
+export default function WorkOrdersScreen() {
+  const { mechanicId } = useContext(AuthContext);
+  const [orders, setOrders] = useState<WorkOrder[]>([]);
+  const [loading, setLoading] = useState(true);
+  const navigation = useNavigation<any>();
+
+  useEffect(() => {
+    const load = async () => {
+      if (!mechanicId) return;
+      try {
+        const data = await getWorkOrders(mechanicId);
+        setOrders(data);
+      } catch (e) {
+        console.error(e);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [mechanicId]);
+
+  if (loading) {
+    return (
+      <View style={styles.center}> 
+        <ActivityIndicator size="large" color="#ff00ff" />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <FlatList
+        data={orders}
+        keyExtractor={(item) => item.estimateNo.toString()}
+        renderItem={({ item }) => (
+          <WorkOrderCard
+            order={item}
+            onPress={() => navigation.navigate('Inspection', { order: item })}
+          />
+        )}
+        contentContainerStyle={{ padding: 16 }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#1c1c1c',
+  },
+  center: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#1c1c1c',
+  },
+});

--- a/frontend/screens/index.ts
+++ b/frontend/screens/index.ts
@@ -1,1 +1,3 @@
 export { default as LoginScreen } from './LoginScreen';
+export { default as WorkOrdersScreen } from './WorkOrdersScreen';
+export { default as InspectionScreen } from './InspectionScreen';

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -4,4 +4,9 @@ const api = axios.create({
   baseURL: process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3000/api',
 });
 
+export async function getWorkOrders(mechanicId: string) {
+  const response = await api.get(`/workorders/${mechanicId}`);
+  return response.data;
+}
+
 export default api;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -6,7 +6,9 @@
     "allowJs": true,
     "strict": true,
     "moduleResolution": "node",
-    "noEmit": true
+    "noEmit": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- add backend API route for fetching work orders
- create frontend WorkOrdersScreen with cards
- add WorkOrderCard component
- wire up navigation after login
- support fetching work orders via service

## Testing
- `npx tsc -p frontend/tsconfig.json`
- `npx tsc -p backend/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6850b778add4832f9d71a2df2e634e98