### PR TITLE
Add work orders endpoint

### DIFF
--- a/backend/controllers/workOrdersController.ts
+++ b/backend/controllers/workOrdersController.ts
@@ -1,0 +1,18 @@
+import { Request, Response } from 'express';
+import * as workOrdersService from '../services/workOrdersService';
+
+export async function getWorkOrders(req: Request, res: Response): Promise<void> {
+  const mechanicId = parseInt(req.params.mechanicId || '', 10);
+  if (!mechanicId) {
+    res.status(400).json({ message: 'mechanicId required' });
+    return;
+  }
+
+  try {
+    const orders = await workOrdersService.findByMechanicId(mechanicId);
+    res.json(orders);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: 'Server error' });
+  }
+}

--- a/backend/models/estimateModel.ts
+++ b/backend/models/estimateModel.ts
@@ -1,0 +1,9 @@
+export interface Estimate {
+  workOrderId: number;
+  year: string;
+  make: string;
+  model: string;
+  license: string;
+  status: string;
+  date: Date;
+}

--- a/backend/routes/index.ts
+++ b/backend/routes/index.ts
@@ -5,7 +5,7 @@ import workOrderRoutes from './workOrders';
 const router = Router();
 
 router.use('/auth', authRoutes);
-router.use('/workorders', workOrderRoutes);
+router.use('/work-orders', workOrderRoutes);
 
 export default router;
 

--- a/backend/routes/workOrders.ts
+++ b/backend/routes/workOrders.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { getWorkOrders } from '../controllers/workOrderController';
+import { getWorkOrders } from '../controllers/workOrdersController';
 
 const router = Router();
 

--- a/backend/services/workOrdersService.ts
+++ b/backend/services/workOrdersService.ts
@@ -1,0 +1,22 @@
+import { sql, poolPromise } from '../database/sql';
+import { Estimate } from '../models/estimateModel';
+
+export async function findByMechanicId(mechanicId: number): Promise<Estimate[]> {
+  const pool = await poolPromise;
+  const result = await pool
+    .request()
+    .input('mechanicId', sql.Int, mechanicId)
+    .query(
+      'SELECT WORK_ORDER_ID, YEAR, MAKE, MODEL, LICENSE, STATUS, DATE FROM ESTMTEHDR WHERE TECH_ID = @mechanicId'
+    );
+
+  return result.recordset.map((row: any) => ({
+    workOrderId: row.WORK_ORDER_ID,
+    year: row.YEAR,
+    make: row.MAKE,
+    model: row.MODEL,
+    license: row.LICENSE,
+    status: row.STATUS,
+    date: row.DATE,
+  }));
+}

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -5,7 +5,7 @@ const api = axios.create({
 });
 
 export async function getWorkOrders(mechanicId: string) {
-  const response = await api.get(`/workorders/${mechanicId}`);
+  const response = await api.get(`/work-orders/${mechanicId}`);
   return response.data;
 }
 


### PR DESCRIPTION
## Summary
- create `Estimate` model for returning work orders
- add service to query `ESTMTEHDR` by mechanic ID
- implement controller and routing for `/work-orders`
- update route mount path and frontend API helper

## Testing
- `npx tsc -p backend/tsconfig.json --noEmit`
- `npx tsc -p tsconfig.json --noEmit` in frontend

------
https://chatgpt.com/codex/tasks/task_e_6850b9447ed0832fbd974046c5814130