### PR TITLE
Add inspection workflow UI

### DIFF
--- a/frontend/components/InspectionItemCard.tsx
+++ b/frontend/components/InspectionItemCard.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, View, Text, StyleSheet } from 'react-native';
+import StatusSelector, { Status } from './StatusSelector';
+import TextInput from './TextInput';
+import PhotoUploader from './PhotoUploader';
+
+export interface InspectionItem {
+  id: number;
+  partNumber: string;
+  description: string;
+  status?: Status | null;
+  reason?: string;
+  photo?: string;
+}
+
+interface Props {
+  item: InspectionItem;
+  onChange: (item: InspectionItem) => void;
+}
+
+export default function InspectionItemCard({ item, onChange }: Props) {
+  const slideAnim = useRef(new Animated.Value(50)).current;
+
+  useEffect(() => {
+    Animated.timing(slideAnim, {
+      toValue: 0,
+      duration: 300,
+      useNativeDriver: true,
+    }).start();
+  }, [slideAnim]);
+
+  const update = (updates: Partial<InspectionItem>) => {
+    onChange({ ...item, ...updates });
+  };
+
+  return (
+    <Animated.View style={[styles.card, { transform: [{ translateX: slideAnim }] }]}>
+      <Text style={styles.title}>{item.partNumber}</Text>
+      <Text style={styles.desc}>{item.description}</Text>
+      <StatusSelector value={item.status || null} onChange={(s) => update({ status: s })} />
+      <TextInput
+        placeholder="Reason (optional)"
+        value={item.reason}
+        onChangeText={(t) => update({ reason: t })}
+      />
+      <PhotoUploader value={item.photo} onChange={(uri) => update({ photo: uri })} />
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#2b2b2b',
+    padding: 12,
+    borderRadius: 8,
+    marginBottom: 12,
+  },
+  title: {
+    color: '#fff',
+    fontWeight: '700',
+    marginBottom: 4,
+  },
+  desc: {
+    color: '#eaeaea',
+    marginBottom: 8,
+  },
+});

--- a/frontend/components/PhotoUploader.tsx
+++ b/frontend/components/PhotoUploader.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { View, Image, TouchableOpacity, Text, StyleSheet } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+
+interface Props {
+  value?: string | null;
+  onChange: (uri: string) => void;
+}
+
+export default function PhotoUploader({ value, onChange }: Props) {
+  const pick = async (useCamera: boolean) => {
+    const result = useCamera
+      ? await ImagePicker.launchCameraAsync({ quality: 0.5 })
+      : await ImagePicker.launchImageLibraryAsync({ quality: 0.5 });
+    if (!result.canceled) {
+      onChange(result.assets[0].uri);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      {value && <Image source={{ uri: value }} style={styles.image} />}
+      <View style={styles.buttons}>
+        <TouchableOpacity style={styles.button} onPress={() => pick(true)}>
+          <Text style={styles.text}>Camera</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.button} onPress={() => pick(false)}>
+          <Text style={styles.text}>Gallery</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { alignItems: 'center', marginVertical: 8 },
+  image: { width: 100, height: 100, borderRadius: 4, marginBottom: 8 },
+  buttons: { flexDirection: 'row' },
+  button: {
+    backgroundColor: '#2b2b2b',
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 4,
+    marginHorizontal: 4,
+  },
+  text: { color: '#fff', fontSize: 12 },
+});

--- a/frontend/components/StatusSelector.tsx
+++ b/frontend/components/StatusSelector.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { View, TouchableOpacity, Text, StyleSheet } from 'react-native';
+
+export type Status = 'green' | 'yellow' | 'red' | 'na';
+
+interface Props {
+  value: Status | null;
+  onChange: (status: Status) => void;
+}
+
+const options: { label: string; value: Status; color: string }[] = [
+  { label: 'Green', value: 'green', color: '#2ecc71' },
+  { label: 'Yellow', value: 'yellow', color: '#f1c40f' },
+  { label: 'Red', value: 'red', color: '#e74c3c' },
+  { label: 'N/A', value: 'na', color: '#7f8c8d' },
+];
+
+export default function StatusSelector({ value, onChange }: Props) {
+  return (
+    <View style={styles.container}>
+      {options.map((opt) => (
+        <TouchableOpacity
+          key={opt.value}
+          style={[
+            styles.button,
+            { backgroundColor: opt.color, opacity: value === opt.value ? 1 : 0.5 },
+          ]}
+          onPress={() => onChange(opt.value)}
+        >
+          <Text style={styles.text}>{opt.label}</Text>
+        </TouchableOpacity>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginVertical: 8,
+  },
+  button: {
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 4,
+  },
+  text: {
+    color: '#fff',
+    fontWeight: '600',
+    fontSize: 12,
+  },
+});

--- a/frontend/components/index.ts
+++ b/frontend/components/index.ts
@@ -1,3 +1,6 @@
 export { default as TextInput } from './TextInput';
 export { default as Button } from './Button';
 export { default as WorkOrderCard } from './WorkOrderCard';
+export { default as StatusSelector } from './StatusSelector';
+export { default as PhotoUploader } from './PhotoUploader';
+export { default as InspectionItemCard } from './InspectionItemCard';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "react": "18.x",
     "react-native": "0.72.x",
     "react-native-safe-area-context": "^4.6.3",
-    "react-native-screens": "~3.22.0"
+    "react-native-screens": "~3.22.0",
+    "expo-image-picker": "^14.0.0"
   },
   "devDependencies": {
     "@types/react": "^19.1.8",

--- a/frontend/screens/InspectionScreen.tsx
+++ b/frontend/screens/InspectionScreen.tsx
@@ -1,10 +1,78 @@
-import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View, FlatList, StyleSheet, ActivityIndicator } from 'react-native';
+import { RouteProp, useRoute } from '@react-navigation/native';
+import { getLineItems, submitInspection } from '../services/api';
+import { InspectionItemCard, Button } from '../components';
+import type { InspectionItem } from '../components/InspectionItemCard';
+
+interface RouteParams {
+  order: {
+    estimateNo: number;
+  };
+}
 
 export default function InspectionScreen() {
+  const route = useRoute<RouteProp<Record<string, RouteParams>, string>>();
+  const order = (route.params as RouteParams).order;
+  const [items, setItems] = useState<InspectionItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await getLineItems(order.estimateNo);
+        setItems(data.map((it: any, idx: number) => ({
+          id: it.id || idx,
+          partNumber: it.PART_NUMBER || it.partNumber,
+          description: it.DESCRIPTION || it.description,
+          status: null,
+        })));
+      } catch (e) {
+        console.error(e);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [order]);
+
+  const updateItem = (updated: InspectionItem) => {
+    setItems((prev) => prev.map((i) => (i.id === updated.id ? updated : i)));
+  };
+
+  const handleSubmit = async () => {
+    setSubmitting(true);
+    try {
+      await submitInspection({ orderId: order.estimateNo, items });
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" color="#ff00ff" />
+      </View>
+    );
+  }
+
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>Inspection Screen</Text>
+      <FlatList
+        data={items}
+        keyExtractor={(item) => item.id.toString()}
+        renderItem={({ item }) => (
+          <InspectionItemCard item={item} onChange={updateItem} />
+        )}
+        contentContainerStyle={{ padding: 16 }}
+      />
+      <View style={styles.submit}>
+        <Button title="Submit" onPress={handleSubmit} loading={submitting} />
+      </View>
     </View>
   );
 }
@@ -13,10 +81,15 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#1c1c1c',
+  },
+  center: {
+    flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
+    backgroundColor: '#1c1c1c',
   },
-  text: {
-    color: '#fff',
+  submit: {
+    paddingHorizontal: 16,
+    paddingBottom: 20,
   },
 });

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -9,4 +9,14 @@ export async function getWorkOrders(mechanicId: string) {
   return response.data;
 }
 
+export async function getLineItems(orderId: number) {
+  const response = await api.get(`/line-items/${orderId}`);
+  return response.data;
+}
+
+export async function submitInspection(data: any) {
+  const response = await api.post('/inspections', data);
+  return response.data;
+}
+
 export default api;


### PR DESCRIPTION
## Summary
- implement inspection data fetch & submit API helpers
- create status selector and photo uploader components
- create inspection item card with animated entry
- build inspection screen with list of line items
- export new components and update dependencies

## Testing
- `npx tsc --noEmit -p frontend/tsconfig.json`
- `npx tsc --noEmit -p backend/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6850ba8d4464832f99ab03c5e974ea35