### PR TITLE
Add inspection endpoints

### DIFF
--- a/backend/controllers/inspectionController.ts
+++ b/backend/controllers/inspectionController.ts
@@ -1,0 +1,34 @@
+import { Request, Response } from 'express';
+import * as inspectionService from '../services/inspectionService';
+
+export async function getLineItems(req: Request, res: Response): Promise<void> {
+  const orderId = parseInt(req.params.orderId || '', 10);
+  if (!orderId) {
+    res.status(400).json({ message: 'orderId required' });
+    return;
+  }
+
+  try {
+    const items = await inspectionService.findLineItems(orderId);
+    res.json(items);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: 'Server error' });
+  }
+}
+
+export async function submitInspection(req: Request, res: Response): Promise<void> {
+  const { orderId, mechanicId, items } = req.body;
+  if (!orderId || !mechanicId || !Array.isArray(items)) {
+    res.status(400).json({ message: 'orderId, mechanicId and items are required' });
+    return;
+  }
+
+  try {
+    await inspectionService.submitInspection(orderId, mechanicId, items);
+    res.json({ message: 'Inspection submitted' });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: 'Server error' });
+  }
+}

--- a/backend/models/lineItemModel.ts
+++ b/backend/models/lineItemModel.ts
@@ -1,0 +1,8 @@
+export interface LineItem {
+  id: number;
+  partNumber: string;
+  description: string;
+  status?: string | null;
+  reason?: string | null;
+  photo?: string | null;
+}

--- a/backend/routes/index.ts
+++ b/backend/routes/index.ts
@@ -1,11 +1,13 @@
 import { Router } from 'express';
 import authRoutes from './auth';
 import workOrderRoutes from './workOrders';
+import inspectionRoutes from './inspections';
 
 const router = Router();
 
 router.use('/auth', authRoutes);
 router.use('/work-orders', workOrderRoutes);
+router.use('/', inspectionRoutes);
 
 export default router;
 

--- a/backend/routes/inspections.ts
+++ b/backend/routes/inspections.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { getLineItems, submitInspection } from '../controllers/inspectionController';
+
+const router = Router();
+
+router.get('/line-items/:orderId', getLineItems);
+router.post('/inspections/submit', submitInspection);
+
+export default router;

--- a/backend/services/inspectionService.ts
+++ b/backend/services/inspectionService.ts
@@ -1,0 +1,48 @@
+import { sql, poolPromise } from '../database/sql';
+import { LineItem } from '../models/lineItemModel';
+
+export interface InspectionItemInput {
+  lineItemId: number;
+  status: string;
+  reason?: string;
+  photo?: string;
+}
+
+export async function findLineItems(orderId: number): Promise<LineItem[]> {
+  const pool = await poolPromise;
+  const result = await pool
+    .request()
+    .input('OrderID', sql.Int, orderId)
+    .query(
+      'SELECT LINE_ITEM_ID, PART_NUMBER, DESCRIPTION FROM LINEITEM WHERE WORK_ORDER_ID = @OrderID'
+    );
+
+  return result.recordset.map((row: any) => ({
+    id: row.LINE_ITEM_ID,
+    partNumber: row.PART_NUMBER,
+    description: row.DESCRIPTION,
+  }));
+}
+
+export async function submitInspection(
+  orderId: number,
+  mechanicId: number,
+  items: InspectionItemInput[]
+): Promise<void> {
+  const pool = await poolPromise;
+  for (const item of items) {
+    await pool
+      .request()
+      .input('OrderID', sql.Int, orderId)
+      .input('LineItemID', sql.Int, item.lineItemId)
+      .input('MechanicID', sql.Int, mechanicId)
+      .input('Status', sql.VarChar, item.status)
+      .input('Reason', sql.VarChar, item.reason || null)
+      .input('Photo', sql.VarChar, item.photo || null)
+      .input('Timestamp', sql.DateTime, new Date())
+      .query(
+        'INSERT INTO INSPECTIONRESULTS (WORK_ORDER_ID, LINE_ITEM_ID, MECHANIC_ID, STATUS, REASON, PHOTO_URL, TIMESTAMP) ' +
+          'VALUES (@OrderID, @LineItemID, @MechanicID, @Status, @Reason, @Photo, @Timestamp)'
+      );
+  }
+}


### PR DESCRIPTION
## Summary
- add `lineItemModel` for inspection line items
- create `inspectionService` to load and save inspection data
- wire inspection endpoints in `inspectionController` and routes
- expose inspection routes from router index

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6850bbf74810832fa0ae603dc9957efe