### PR TITLE
Add offline caching and theming

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { AuthProvider, AuthContext } from './contexts';
+import { AuthProvider, AuthContext, ThemeProvider } from './contexts';
 import { LoginScreen, WorkOrdersScreen, InspectionScreen } from './screens';
 
 const Stack = createNativeStackNavigator();
@@ -27,8 +27,10 @@ function RootNavigator() {
 
 export default function App() {
   return (
-    <AuthProvider>
-      <RootNavigator />
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <RootNavigator />
+      </AuthProvider>
+    </ThemeProvider>
   );
 }

--- a/frontend/components/Button.tsx
+++ b/frontend/components/Button.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { TouchableOpacity, Text, StyleSheet, ActivityIndicator, ViewStyle } from 'react-native';
+import { ThemeContext } from '../contexts';
 
 interface Props {
   title: string;
@@ -9,9 +10,18 @@ interface Props {
 }
 
 export default function Button({ title, onPress, loading, style }: Props) {
+  const { theme } = useContext(ThemeContext);
   return (
-    <TouchableOpacity style={[styles.button, style]} onPress={onPress} disabled={loading}>
-      {loading ? <ActivityIndicator color="#fff" /> : <Text style={styles.text}>{title}</Text>}
+    <TouchableOpacity
+      style={[styles.button, { backgroundColor: theme.accent }, style]}
+      onPress={onPress}
+      disabled={loading}
+    >
+      {loading ? (
+        <ActivityIndicator color="#fff" />
+      ) : (
+        <Text style={[styles.text, { color: theme.text }]}>{title}</Text>
+      )}
     </TouchableOpacity>
   );
 }

--- a/frontend/components/TextInput.tsx
+++ b/frontend/components/TextInput.tsx
@@ -1,14 +1,20 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { TextInput as RNTextInput, TextInputProps, StyleSheet } from 'react-native';
+import { ThemeContext } from '../contexts';
 
 export default function TextInput(props: TextInputProps) {
-  return <RNTextInput placeholderTextColor="#666" style={styles.input} {...props} />;
+  const { theme } = useContext(ThemeContext);
+  return (
+    <RNTextInput
+      placeholderTextColor="#666"
+      style={[styles.input, { backgroundColor: theme.background, color: theme.text }]}
+      {...props}
+    />
+  );
 }
 
 const styles = StyleSheet.create({
   input: {
-    backgroundColor: '#fff',
-    color: '#000',
     paddingHorizontal: 12,
     paddingVertical: 10,
     borderRadius: 4,

--- a/frontend/components/ThemeToggle.tsx
+++ b/frontend/components/ThemeToggle.tsx
@@ -1,0 +1,24 @@
+import React, { useContext } from 'react';
+import { View, Switch, StyleSheet } from 'react-native';
+import { ThemeContext } from '../contexts';
+
+export default function ThemeToggle() {
+  const { mode, toggleTheme, theme } = useContext(ThemeContext);
+  return (
+    <View style={styles.container}>
+      <Switch
+        value={mode === 'dark'}
+        onValueChange={toggleTheme}
+        thumbColor={theme.accent}
+        trackColor={{ true: theme.accent, false: '#ccc' }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'flex-end',
+    paddingVertical: 8,
+  },
+});

--- a/frontend/components/index.ts
+++ b/frontend/components/index.ts
@@ -4,3 +4,4 @@ export { default as WorkOrderCard } from './WorkOrderCard';
 export { default as StatusSelector } from './StatusSelector';
 export { default as PhotoUploader } from './PhotoUploader';
 export { default as InspectionItemCard } from './InspectionItemCard';
+export { default as ThemeToggle } from './ThemeToggle';

--- a/frontend/contexts/ThemeContext.tsx
+++ b/frontend/contexts/ThemeContext.tsx
@@ -1,0 +1,66 @@
+import React, { createContext, useEffect, useState, ReactNode } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export type ThemeMode = 'light' | 'dark';
+
+export interface Theme {
+  background: string;
+  text: string;
+  accent: string;
+}
+
+const lightTheme: Theme = {
+  background: '#ffffff',
+  text: '#2b2b2b',
+  accent: '#ff00ff',
+};
+
+const darkTheme: Theme = {
+  background: '#2b2b2b',
+  text: '#ffffff',
+  accent: '#ff00ff',
+};
+
+interface ThemeContextProps {
+  mode: ThemeMode;
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const STORAGE_KEY = 'theme-mode';
+
+export const ThemeContext = createContext<ThemeContextProps>({
+  mode: 'dark',
+  theme: darkTheme,
+  toggleTheme: () => {},
+});
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [mode, setMode] = useState<ThemeMode>('dark');
+
+  useEffect(() => {
+    const load = async () => {
+      const saved = await AsyncStorage.getItem(STORAGE_KEY);
+      if (saved === 'light' || saved === 'dark') {
+        setMode(saved);
+      }
+    };
+    load();
+  }, []);
+
+  useEffect(() => {
+    AsyncStorage.setItem(STORAGE_KEY, mode);
+  }, [mode]);
+
+  const toggleTheme = () => {
+    setMode((prev) => (prev === 'dark' ? 'light' : 'dark'));
+  };
+
+  const theme = mode === 'dark' ? darkTheme : lightTheme;
+
+  return (
+    <ThemeContext.Provider value={{ mode, theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/frontend/contexts/index.ts
+++ b/frontend/contexts/index.ts
@@ -1,1 +1,2 @@
 export * from './AuthContext';
+export * from './ThemeContext';

--- a/frontend/hooks/index.ts
+++ b/frontend/hooks/index.ts
@@ -1,1 +1,1 @@
-// TODO: export hooks
+export { default as useOffline } from './useOffline';

--- a/frontend/hooks/useOffline.ts
+++ b/frontend/hooks/useOffline.ts
@@ -1,0 +1,62 @@
+import { useEffect } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import NetInfo from '@react-native-community/netinfo';
+import { submitInspection as apiSubmit } from '../services/api';
+
+const STORAGE_KEY = 'offline-inspections';
+
+export default function useOffline() {
+  useEffect(() => {
+    const unsubscribe = NetInfo.addEventListener(state => {
+      if (state.isConnected) {
+        flushQueue();
+      }
+    });
+    flushQueue();
+    return unsubscribe;
+  }, []);
+
+  const flushQueue = async () => {
+    const json = await AsyncStorage.getItem(STORAGE_KEY);
+    if (!json) return;
+    let queue: any[] = [];
+    try {
+      queue = JSON.parse(json);
+    } catch {}
+    const remaining: any[] = [];
+    for (const item of queue) {
+      try {
+        await apiSubmit(item);
+      } catch {
+        remaining.push(item);
+      }
+    }
+    if (remaining.length) {
+      await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(remaining));
+    } else {
+      await AsyncStorage.removeItem(STORAGE_KEY);
+    }
+  };
+
+  const enqueue = async (data: any) => {
+    const json = await AsyncStorage.getItem(STORAGE_KEY);
+    const queue = json ? JSON.parse(json) : [];
+    queue.push(data);
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(queue));
+  };
+
+  const submitInspection = async (data: any) => {
+    const state = await NetInfo.fetch();
+    if (state.isConnected) {
+      try {
+        await apiSubmit(data);
+        return;
+      } catch {
+        // fall through to queue
+      }
+    }
+    await enqueue(data);
+  };
+
+  return { submitInspection };
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,9 @@
     "react-native": "0.72.x",
     "react-native-safe-area-context": "^4.6.3",
     "react-native-screens": "~3.22.0",
-    "expo-image-picker": "^14.0.0"
+    "expo-image-picker": "^14.0.0",
+    "@react-native-async-storage/async-storage": "^1.20.0",
+    "@react-native-community/netinfo": "^9.4.1"
   },
   "devDependencies": {
     "@types/react": "^19.1.8",

--- a/frontend/screens/InspectionScreen.tsx
+++ b/frontend/screens/InspectionScreen.tsx
@@ -1,8 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import { View, FlatList, StyleSheet, ActivityIndicator } from 'react-native';
 import { RouteProp, useRoute } from '@react-navigation/native';
-import { getLineItems, submitInspection } from '../services/api';
+import { getLineItems } from '../services/api';
 import { InspectionItemCard, Button } from '../components';
+import { ThemeContext } from '../contexts';
+import { useOffline } from '../hooks';
 import type { InspectionItem } from '../components/InspectionItemCard';
 
 interface RouteParams {
@@ -17,6 +19,8 @@ export default function InspectionScreen() {
   const [items, setItems] = useState<InspectionItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
+  const { theme } = useContext(ThemeContext);
+  const { submitInspection } = useOffline();
 
   useEffect(() => {
     const load = async () => {
@@ -43,25 +47,20 @@ export default function InspectionScreen() {
 
   const handleSubmit = async () => {
     setSubmitting(true);
-    try {
-      await submitInspection({ orderId: order.estimateNo, items });
-    } catch (e) {
-      console.error(e);
-    } finally {
-      setSubmitting(false);
-    }
+    await submitInspection({ orderId: order.estimateNo, items });
+    setSubmitting(false);
   };
 
   if (loading) {
     return (
-      <View style={styles.center}>
+      <View style={[styles.center, { backgroundColor: theme.background }]}>
         <ActivityIndicator size="large" color="#ff00ff" />
       </View>
     );
   }
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: theme.background }]}>
       <FlatList
         data={items}
         keyExtractor={(item) => item.id.toString()}
@@ -80,13 +79,11 @@ export default function InspectionScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#1c1c1c',
   },
   center: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#1c1c1c',
   },
   submit: {
     paddingHorizontal: 16,

--- a/frontend/screens/LoginScreen.tsx
+++ b/frontend/screens/LoginScreen.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useContext } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { TextInput, Button } from '../components';
+import { TextInput, Button, ThemeToggle } from '../components';
 import api from '../services/api';
-import { AuthContext } from '../contexts';
+import { AuthContext, ThemeContext } from '../contexts';
 
 export default function LoginScreen() {
   const { login } = useContext(AuthContext);
+  const { theme } = useContext(ThemeContext);
   const [mechanicId, setMechanicId] = useState('');
   const [pin, setPin] = useState('');
   const [loading, setLoading] = useState(false);
@@ -30,8 +31,9 @@ export default function LoginScreen() {
   };
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>Mechanic Login</Text>
+    <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <ThemeToggle />
+      <Text style={[styles.title, { color: theme.text }]}>Mechanic Login</Text>
       <TextInput
         placeholder="Mechanic ID"
         value={mechanicId}
@@ -53,12 +55,10 @@ export default function LoginScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#2b2b2b',
     justifyContent: 'center',
     padding: 20,
   },
   title: {
-    color: '#fff',
     fontSize: 24,
     fontWeight: '600',
     textAlign: 'center',

--- a/frontend/screens/WorkOrdersScreen.tsx
+++ b/frontend/screens/WorkOrdersScreen.tsx
@@ -1,8 +1,9 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { View, FlatList, StyleSheet, ActivityIndicator } from 'react-native';
-import { AuthContext } from '../contexts';
+import { AuthContext, ThemeContext } from '../contexts';
 import { getWorkOrders } from '../services/api';
 import WorkOrderCard from '../components/WorkOrderCard';
+import { ThemeToggle } from '../components';
 import { useNavigation } from '@react-navigation/native';
 
 interface WorkOrder {
@@ -17,6 +18,7 @@ interface WorkOrder {
 
 export default function WorkOrdersScreen() {
   const { mechanicId } = useContext(AuthContext);
+  const { theme } = useContext(ThemeContext);
   const [orders, setOrders] = useState<WorkOrder[]>([]);
   const [loading, setLoading] = useState(true);
   const navigation = useNavigation<any>();
@@ -38,14 +40,15 @@ export default function WorkOrdersScreen() {
 
   if (loading) {
     return (
-      <View style={styles.center}> 
+      <View style={[styles.center, { backgroundColor: theme.background }]}>
         <ActivityIndicator size="large" color="#ff00ff" />
       </View>
     );
   }
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <ThemeToggle />
       <FlatList
         data={orders}
         keyExtractor={(item) => item.estimateNo.toString()}
@@ -64,12 +67,10 @@ export default function WorkOrdersScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#1c1c1c',
   },
   center: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#1c1c1c',
   },
 });


### PR DESCRIPTION
## Summary
- cache inspections offline until back online
- add theme context with dark and light modes
- toggle theme via a new switch component
- apply theme styles across screens
- expose new offline hook and theme provider

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6850bd1ecb4c832f9a1a020bb99f3eb1