### PR TITLE
Implement offline sync and theme hook

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
-import { AuthProvider, AuthContext, ThemeProvider } from './contexts';
+import { AuthProvider, AuthContext, ThemeProvider, SyncProvider } from './contexts';
 import { LoginScreen, WorkOrdersScreen, InspectionScreen } from './screens';
 
 const Stack = createNativeStackNavigator();
@@ -28,9 +28,11 @@ function RootNavigator() {
 export default function App() {
   return (
     <ThemeProvider>
-      <AuthProvider>
-        <RootNavigator />
-      </AuthProvider>
+      <SyncProvider>
+        <AuthProvider>
+          <RootNavigator />
+        </AuthProvider>
+      </SyncProvider>
     </ThemeProvider>
   );
 }

--- a/frontend/components/Button.tsx
+++ b/frontend/components/Button.tsx
@@ -1,6 +1,6 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { TouchableOpacity, Text, StyleSheet, ActivityIndicator, ViewStyle } from 'react-native';
-import { ThemeContext } from '../contexts';
+import { useTheme } from '../hooks';
 
 interface Props {
   title: string;
@@ -10,7 +10,7 @@ interface Props {
 }
 
 export default function Button({ title, onPress, loading, style }: Props) {
-  const { theme } = useContext(ThemeContext);
+  const { theme } = useTheme();
   return (
     <TouchableOpacity
       style={[styles.button, { backgroundColor: theme.accent }, style]}
@@ -28,13 +28,11 @@ export default function Button({ title, onPress, loading, style }: Props) {
 
 const styles = StyleSheet.create({
   button: {
-    backgroundColor: '#ff00ff',
     paddingVertical: 12,
     alignItems: 'center',
     borderRadius: 4,
   },
   text: {
-    color: '#fff',
     fontWeight: '600',
   },
 });

--- a/frontend/components/InspectionItemCard.tsx
+++ b/frontend/components/InspectionItemCard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { Animated, View, Text, StyleSheet } from 'react-native';
+import { useTheme } from '../hooks';
 import StatusSelector, { Status } from './StatusSelector';
 import TextInput from './TextInput';
 import PhotoUploader from './PhotoUploader';
@@ -20,6 +21,7 @@ interface Props {
 
 export default function InspectionItemCard({ item, onChange }: Props) {
   const slideAnim = useRef(new Animated.Value(50)).current;
+  const { theme } = useTheme();
 
   useEffect(() => {
     Animated.timing(slideAnim, {
@@ -34,9 +36,9 @@ export default function InspectionItemCard({ item, onChange }: Props) {
   };
 
   return (
-    <Animated.View style={[styles.card, { transform: [{ translateX: slideAnim }] }]}>
-      <Text style={styles.title}>{item.partNumber}</Text>
-      <Text style={styles.desc}>{item.description}</Text>
+    <Animated.View style={[styles.card, { transform: [{ translateX: slideAnim }], backgroundColor: theme.background }]}>
+      <Text style={[styles.title, { color: theme.text }]}>{item.partNumber}</Text>
+      <Text style={[styles.desc, { color: theme.text }]}>{item.description}</Text>
       <StatusSelector value={item.status || null} onChange={(s) => update({ status: s })} />
       <TextInput
         placeholder="Reason (optional)"
@@ -56,12 +58,10 @@ const styles = StyleSheet.create({
     marginBottom: 12,
   },
   title: {
-    color: '#fff',
     fontWeight: '700',
     marginBottom: 4,
   },
   desc: {
-    color: '#eaeaea',
     marginBottom: 8,
   },
 });

--- a/frontend/components/PhotoUploader.tsx
+++ b/frontend/components/PhotoUploader.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Image, TouchableOpacity, Text, StyleSheet } from 'react-native';
+import { useTheme } from '../hooks';
 import * as ImagePicker from 'expo-image-picker';
 
 interface Props {
@@ -8,6 +9,7 @@ interface Props {
 }
 
 export default function PhotoUploader({ value, onChange }: Props) {
+  const { theme } = useTheme();
   const pick = async (useCamera: boolean) => {
     const result = useCamera
       ? await ImagePicker.launchCameraAsync({ quality: 0.5 })
@@ -21,11 +23,11 @@ export default function PhotoUploader({ value, onChange }: Props) {
     <View style={styles.container}>
       {value && <Image source={{ uri: value }} style={styles.image} />}
       <View style={styles.buttons}>
-        <TouchableOpacity style={styles.button} onPress={() => pick(true)}>
-          <Text style={styles.text}>Camera</Text>
+        <TouchableOpacity style={[styles.button, { backgroundColor: theme.background }]} onPress={() => pick(true)}>
+          <Text style={[styles.text, { color: theme.text }]}>Camera</Text>
         </TouchableOpacity>
-        <TouchableOpacity style={styles.button} onPress={() => pick(false)}>
-          <Text style={styles.text}>Gallery</Text>
+        <TouchableOpacity style={[styles.button, { backgroundColor: theme.background }]} onPress={() => pick(false)}>
+          <Text style={[styles.text, { color: theme.text }]}>Gallery</Text>
         </TouchableOpacity>
       </View>
     </View>
@@ -37,11 +39,10 @@ const styles = StyleSheet.create({
   image: { width: 100, height: 100, borderRadius: 4, marginBottom: 8 },
   buttons: { flexDirection: 'row' },
   button: {
-    backgroundColor: '#2b2b2b',
     paddingVertical: 6,
     paddingHorizontal: 12,
     borderRadius: 4,
     marginHorizontal: 4,
   },
-  text: { color: '#fff', fontSize: 12 },
+  text: { fontSize: 12 },
 });

--- a/frontend/components/SyncStatusBadge.tsx
+++ b/frontend/components/SyncStatusBadge.tsx
@@ -1,0 +1,34 @@
+import React, { useContext } from 'react';
+import { View, Text, ActivityIndicator, StyleSheet } from 'react-native';
+import { SyncContext, ThemeContext } from '../contexts';
+
+export default function SyncStatusBadge() {
+  const { pending, syncing } = useContext(SyncContext);
+  const { theme } = useContext(ThemeContext);
+
+  if (pending === 0 && !syncing) return null;
+
+  return (
+    <View style={[styles.badge, { backgroundColor: theme.accent }]}>
+      {syncing ? (
+        <ActivityIndicator size="small" color={theme.text} />
+      ) : (
+        <Text style={[styles.text, { color: theme.text }]}>{pending}</Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  badge: {
+    alignSelf: 'flex-end',
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 8,
+    marginBottom: 8,
+  },
+  text: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+});

--- a/frontend/components/TextInput.tsx
+++ b/frontend/components/TextInput.tsx
@@ -1,9 +1,9 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { TextInput as RNTextInput, TextInputProps, StyleSheet } from 'react-native';
-import { ThemeContext } from '../contexts';
+import { useTheme } from '../hooks';
 
 export default function TextInput(props: TextInputProps) {
-  const { theme } = useContext(ThemeContext);
+  const { theme } = useTheme();
   return (
     <RNTextInput
       placeholderTextColor="#666"

--- a/frontend/components/ThemeToggle.tsx
+++ b/frontend/components/ThemeToggle.tsx
@@ -1,9 +1,9 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { View, Switch, StyleSheet } from 'react-native';
-import { ThemeContext } from '../contexts';
+import { useTheme } from '../hooks';
 
 export default function ThemeToggle() {
-  const { mode, toggleTheme, theme } = useContext(ThemeContext);
+  const { mode, toggleTheme, theme } = useTheme();
   return (
     <View style={styles.container}>
       <Switch

--- a/frontend/components/WorkOrderCard.tsx
+++ b/frontend/components/WorkOrderCard.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { Animated, TouchableOpacity, Text, StyleSheet, ViewStyle } from 'react-native';
+import { useTheme } from '../hooks';
 
 interface Props {
   order: {
@@ -17,6 +18,7 @@ interface Props {
 
 export default function WorkOrderCard({ order, onPress, style }: Props) {
   const fadeAnim = useRef(new Animated.Value(0)).current;
+  const { theme } = useTheme();
 
   useEffect(() => {
     Animated.timing(fadeAnim, {
@@ -27,12 +29,12 @@ export default function WorkOrderCard({ order, onPress, style }: Props) {
   }, [fadeAnim]);
 
   return (
-    <Animated.View style={[styles.card, style, { opacity: fadeAnim }]}> 
+    <Animated.View style={[styles.card, style, { opacity: fadeAnim, backgroundColor: theme.background }]}>
       <TouchableOpacity onPress={onPress}>
-        <Text style={styles.title}>WO #{order.estimateNo}</Text>
-        <Text style={styles.text}>{order.vehYear} {order.vehMake} {order.vehModel}</Text>
-        <Text style={styles.text}>License: {order.license}</Text>
-        <Text style={styles.sub}>{new Date(order.date).toLocaleDateString()} • {order.status}</Text>
+        <Text style={[styles.title, { color: theme.text }]}>WO #{order.estimateNo}</Text>
+        <Text style={[styles.text, { color: theme.text }]}>{order.vehYear} {order.vehMake} {order.vehModel}</Text>
+        <Text style={[styles.text, { color: theme.text }]}>License: {order.license}</Text>
+        <Text style={[styles.sub, { color: theme.text }]}>{new Date(order.date).toLocaleDateString()} • {order.status}</Text>
       </TouchableOpacity>
     </Animated.View>
   );
@@ -40,7 +42,6 @@ export default function WorkOrderCard({ order, onPress, style }: Props) {
 
 const styles = StyleSheet.create({
   card: {
-    backgroundColor: '#2b2b2b',
     padding: 16,
     borderRadius: 8,
     marginBottom: 12,
@@ -50,17 +51,14 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 3 },
   },
   title: {
-    color: '#fff',
     fontSize: 18,
     fontWeight: '700',
     marginBottom: 4,
   },
   text: {
-    color: '#eaeaea',
     fontSize: 14,
   },
   sub: {
-    color: '#bbbbbb',
     marginTop: 6,
     fontSize: 12,
   },

--- a/frontend/components/index.ts
+++ b/frontend/components/index.ts
@@ -5,3 +5,4 @@ export { default as StatusSelector } from './StatusSelector';
 export { default as PhotoUploader } from './PhotoUploader';
 export { default as InspectionItemCard } from './InspectionItemCard';
 export { default as ThemeToggle } from './ThemeToggle';
+export { default as SyncStatusBadge } from './SyncStatusBadge';

--- a/frontend/contexts/SyncContext.tsx
+++ b/frontend/contexts/SyncContext.tsx
@@ -1,0 +1,69 @@
+import React, { createContext, ReactNode, useCallback, useEffect, useState } from 'react';
+import { AppState } from 'react-native';
+import { submitInspection } from '../services/api';
+import useNetworkStatus from '../hooks/useNetworkStatus';
+import { enqueue as enqueueItem, getQueue, flushQueue } from '../utils/syncQueue';
+
+interface SyncContextProps {
+  pending: number;
+  syncing: boolean;
+  enqueue: (data: any) => Promise<void>;
+}
+
+export const SyncContext = createContext<SyncContextProps>({
+  pending: 0,
+  syncing: false,
+  enqueue: async () => {},
+});
+
+export const SyncProvider = ({ children }: { children: ReactNode }) => {
+  const { isConnected } = useNetworkStatus();
+  const [pending, setPending] = useState(0);
+  const [syncing, setSyncing] = useState(false);
+
+  const loadPending = useCallback(async () => {
+    const q = await getQueue();
+    setPending(q.length);
+  }, []);
+
+  const processQueue = useCallback(async () => {
+    if (!isConnected) return;
+    setSyncing(true);
+    await flushQueue(submitInspection);
+    setSyncing(false);
+    loadPending();
+  }, [isConnected, loadPending]);
+
+  useEffect(() => {
+    loadPending();
+  }, [loadPending]);
+
+  useEffect(() => {
+    if (isConnected) {
+      processQueue();
+    }
+  }, [isConnected, processQueue]);
+
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', state => {
+      if (state === 'active') {
+        processQueue();
+      }
+    });
+    return () => sub.remove();
+  }, [processQueue]);
+
+  const enqueue = async (data: any) => {
+    await enqueueItem(data);
+    loadPending();
+    if (isConnected) {
+      processQueue();
+    }
+  };
+
+  return (
+    <SyncContext.Provider value={{ pending, syncing, enqueue }}>
+      {children}
+    </SyncContext.Provider>
+  );
+};

--- a/frontend/contexts/index.ts
+++ b/frontend/contexts/index.ts
@@ -1,2 +1,3 @@
 export * from './AuthContext';
 export * from './ThemeContext';
+export * from './SyncContext';

--- a/frontend/hooks/index.ts
+++ b/frontend/hooks/index.ts
@@ -1,1 +1,3 @@
 export { default as useOffline } from './useOffline';
+export { default as useNetworkStatus } from './useNetworkStatus';
+export { default as useTheme } from './useTheme';

--- a/frontend/hooks/useNetworkStatus.ts
+++ b/frontend/hooks/useNetworkStatus.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+import NetInfo, { NetInfoState } from '@react-native-community/netinfo';
+
+export default function useNetworkStatus() {
+  const [isConnected, setIsConnected] = useState<boolean>(false);
+
+  useEffect(() => {
+    const handle = (state: NetInfoState) => {
+      setIsConnected(state.isConnected ?? false);
+    };
+    const unsubscribe = NetInfo.addEventListener(handle);
+    NetInfo.fetch().then(handle);
+    return unsubscribe;
+  }, []);
+
+  return { isConnected };
+}

--- a/frontend/hooks/useTheme.ts
+++ b/frontend/hooks/useTheme.ts
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import { ThemeContext } from '../contexts';
+
+export default function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/frontend/screens/InspectionScreen.tsx
+++ b/frontend/screens/InspectionScreen.tsx
@@ -2,9 +2,9 @@ import React, { useEffect, useState, useContext } from 'react';
 import { View, FlatList, StyleSheet, ActivityIndicator } from 'react-native';
 import { RouteProp, useRoute } from '@react-navigation/native';
 import { getLineItems } from '../services/api';
-import { InspectionItemCard, Button } from '../components';
-import { ThemeContext } from '../contexts';
-import { useOffline } from '../hooks';
+import { InspectionItemCard, Button, SyncStatusBadge } from '../components';
+import { SyncContext } from '../contexts';
+import { useTheme } from '../hooks';
 import type { InspectionItem } from '../components/InspectionItemCard';
 
 interface RouteParams {
@@ -19,8 +19,8 @@ export default function InspectionScreen() {
   const [items, setItems] = useState<InspectionItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
-  const { theme } = useContext(ThemeContext);
-  const { submitInspection } = useOffline();
+  const { theme } = useTheme();
+  const { enqueue } = useContext(SyncContext);
 
   useEffect(() => {
     const load = async () => {
@@ -47,7 +47,7 @@ export default function InspectionScreen() {
 
   const handleSubmit = async () => {
     setSubmitting(true);
-    await submitInspection({ orderId: order.estimateNo, items });
+    await enqueue({ orderId: order.estimateNo, items });
     setSubmitting(false);
   };
 
@@ -61,6 +61,7 @@ export default function InspectionScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <SyncStatusBadge />
       <FlatList
         data={items}
         keyExtractor={(item) => item.id.toString()}

--- a/frontend/screens/LoginScreen.tsx
+++ b/frontend/screens/LoginScreen.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useContext } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { TextInput, Button, ThemeToggle } from '../components';
+import { TextInput, Button, ThemeToggle, SyncStatusBadge } from '../components';
 import api from '../services/api';
-import { AuthContext, ThemeContext } from '../contexts';
+import { AuthContext } from '../contexts';
+import { useTheme } from '../hooks';
 
 export default function LoginScreen() {
   const { login } = useContext(AuthContext);
-  const { theme } = useContext(ThemeContext);
+  const { theme } = useTheme();
   const [mechanicId, setMechanicId] = useState('');
   const [pin, setPin] = useState('');
   const [loading, setLoading] = useState(false);
@@ -32,6 +33,7 @@ export default function LoginScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <SyncStatusBadge />
       <ThemeToggle />
       <Text style={[styles.title, { color: theme.text }]}>Mechanic Login</Text>
       <TextInput

--- a/frontend/screens/WorkOrdersScreen.tsx
+++ b/frontend/screens/WorkOrdersScreen.tsx
@@ -1,9 +1,10 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { View, FlatList, StyleSheet, ActivityIndicator } from 'react-native';
-import { AuthContext, ThemeContext } from '../contexts';
+import { AuthContext } from '../contexts';
+import { useTheme } from '../hooks';
 import { getWorkOrders } from '../services/api';
 import WorkOrderCard from '../components/WorkOrderCard';
-import { ThemeToggle } from '../components';
+import { ThemeToggle, SyncStatusBadge } from '../components';
 import { useNavigation } from '@react-navigation/native';
 
 interface WorkOrder {
@@ -18,7 +19,7 @@ interface WorkOrder {
 
 export default function WorkOrdersScreen() {
   const { mechanicId } = useContext(AuthContext);
-  const { theme } = useContext(ThemeContext);
+  const { theme } = useTheme();
   const [orders, setOrders] = useState<WorkOrder[]>([]);
   const [loading, setLoading] = useState(true);
   const navigation = useNavigation<any>();
@@ -48,6 +49,7 @@ export default function WorkOrdersScreen() {
 
   return (
     <View style={[styles.container, { backgroundColor: theme.background }]}>
+      <SyncStatusBadge />
       <ThemeToggle />
       <FlatList
         data={orders}

--- a/frontend/utils/syncQueue.ts
+++ b/frontend/utils/syncQueue.ts
@@ -1,0 +1,43 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = 'pending-inspections';
+
+export type QueueItem = any;
+
+export async function getQueue(): Promise<QueueItem[]> {
+  const json = await AsyncStorage.getItem(STORAGE_KEY);
+  if (!json) return [];
+  try {
+    return JSON.parse(json);
+  } catch {
+    return [];
+  }
+}
+
+export async function setQueue(items: QueueItem[]): Promise<void> {
+  if (!items.length) {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+    return;
+  }
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+}
+
+export async function enqueue(item: QueueItem): Promise<void> {
+  const queue = await getQueue();
+  queue.push(item);
+  await setQueue(queue);
+}
+
+export async function flushQueue(uploader: (item: QueueItem) => Promise<void>): Promise<void> {
+  const queue = await getQueue();
+  if (!queue.length) return;
+  const remaining: QueueItem[] = [];
+  for (const item of queue) {
+    try {
+      await uploader(item);
+    } catch {
+      remaining.push(item);
+    }
+  }
+  await setQueue(remaining);
+}


### PR DESCRIPTION
## Summary
- support offline inspection queue
- show a sync status badge
- wrap app in `SyncProvider`
- centralize theme access with `useTheme` hook
- themeify buttons, inputs, and cards

## Testing
- `npx tsc --noEmit -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_6850c1e5cfec832f92de7078753a298f