### PR TITLE
Implement company listing and revise mechanic endpoints

### DIFF
--- a/backend/controllers/companyController.ts
+++ b/backend/controllers/companyController.ts
@@ -1,0 +1,11 @@
+import { Request, Response, NextFunction } from 'express';
+import * as companyService from '../services/companyService';
+
+export async function getCompanies(req: Request, res: Response, next: NextFunction): Promise<void> {
+  try {
+    const companies = await companyService.list();
+    res.json(companies);
+  } catch (error) {
+    next(error);
+  }
+}

--- a/backend/controllers/mechanicController.ts
+++ b/backend/controllers/mechanicController.ts
@@ -1,12 +1,9 @@
 import { Request, Response, NextFunction } from 'express';
-import jwt from 'jsonwebtoken';
 import * as mechanicService from '../services/mechanicService';
 import {
   mechanicsParamsSchema,
   mechanicLoginSchema,
 } from '../validators/mechanicValidator';
-
-const JWT_SECRET = process.env.JWT_SECRET as string;
 
 export async function getMechanics(
   req: Request,
@@ -38,16 +35,10 @@ export async function verifyLogin(
       res.status(401).json({ error: 'Invalid credentials', status: 401 });
       return;
     }
-    const token = jwt.sign(
-      { mechanicId: mech.mechanicId, role: mech.role },
-      JWT_SECRET,
-      { expiresIn: '1h' }
-    );
     res.json({
-      mechanicId: mech.mechanicId,
+      mechanicNumber: mech.mechanicId,
       name: mech.name,
       role: mech.role,
-      token,
     });
   } catch (error: any) {
     if (error?.issues) {

--- a/backend/models/mechanicModel.ts
+++ b/backend/models/mechanicModel.ts
@@ -2,5 +2,6 @@ export interface Mechanic {
   mechanicId: number;
   name: string;
   role: 'S' | 'T' | 'B';
-  pin: string;
+  pin?: string;
+  homeShop?: number;
 }

--- a/backend/routes/companies.ts
+++ b/backend/routes/companies.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { getCompanies } from '../controllers/companyController';
+
+const router = Router();
+
+router.get('/', getCompanies);
+
+export default router;

--- a/backend/routes/index.ts
+++ b/backend/routes/index.ts
@@ -4,11 +4,13 @@ import authRoutes from './auth';
 import workOrderRoutes from './workOrders';
 import inspectionRoutes from './inspections';
 import mechanicRoutes from './mechanics';
+import companyRoutes from './companies';
 
 const router = Router();
 
 router.use('/auth', authRoutes);
 router.use('/mechanics', mechanicRoutes);
+router.use('/companies', companyRoutes);
 router.use(authMiddleware);
 router.use('/work-orders', workOrderRoutes);
 router.use('/', inspectionRoutes);

--- a/backend/services/companyService.ts
+++ b/backend/services/companyService.ts
@@ -1,0 +1,7 @@
+import { sql, poolPromise } from '../database/sql';
+
+export async function list(): Promise<number[]> {
+  const pool = await poolPromise;
+  const result = await pool.request().query('SELECT COMPANY_NUMBER FROM COMPANY');
+  return result.recordset.map((row: any) => row.COMPANY_NUMBER);
+}

--- a/backend/services/mechanicService.ts
+++ b/backend/services/mechanicService.ts
@@ -7,16 +7,15 @@ export async function list(companyId: number): Promise<Mechanic[]> {
     .request()
     .input('shopId', sql.Int, companyId)
     .query(
-      `SELECT MECHANIC_NUMBER, MECHANIC_NAME, POPUP_TYPE, TIME_CLOCK_PASSWORD
+      `SELECT MECHANIC_NUMBER, HOME_SHOP, MECHANIC_NAME, POPUP_TYPE, TIME_CLOCK_PASSWORD
        FROM MECHANIC
        WHERE HOME_SHOP = @shopId
-         AND MobileEnabled = 1
-         AND ISNULL(POPUP_TYPE, '') <> ''
-         AND UPPER(CERTIFICATE_NUMBER) <> 'EXPIRED'`
+         AND MobileEnabled = 1`
     );
 
   return result.recordset.map((r: any) => ({
     mechanicId: r.MECHANIC_NUMBER,
+    homeShop: r.HOME_SHOP,
     name: r.MECHANIC_NAME,
     role: r.POPUP_TYPE,
     pin: r.TIME_CLOCK_PASSWORD,
@@ -35,14 +34,12 @@ export async function verifyLogin(
     .input('mechanicNumber', sql.Int, mechanicNumber)
     .input('pin', sql.VarChar, pin)
     .query(
-      `SELECT MECHANIC_NUMBER, MECHANIC_NAME, POPUP_TYPE, TIME_CLOCK_PASSWORD
+      `SELECT MECHANIC_NUMBER, MECHANIC_NAME, POPUP_TYPE
        FROM MECHANIC
        WHERE MECHANIC_NUMBER = @mechanicNumber
          AND TIME_CLOCK_PASSWORD = @pin
          AND HOME_SHOP = @shopId
-         AND MobileEnabled = 1
-         AND ISNULL(POPUP_TYPE, '') <> ''
-         AND UPPER(CERTIFICATE_NUMBER) <> 'EXPIRED'`
+         AND MobileEnabled = 1`
     );
 
   const row = result.recordset[0];
@@ -52,6 +49,5 @@ export async function verifyLogin(
     mechanicId: row.MECHANIC_NUMBER,
     name: row.MECHANIC_NAME,
     role: row.POPUP_TYPE,
-    pin: row.TIME_CLOCK_PASSWORD,
   };
 }


### PR DESCRIPTION
## Summary
- add `GET /companies` endpoint to list company numbers
- return extra fields in mechanic listing and remove unnecessary filters
- simplify mechanic login response and query

## Testing
- `npm install`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68517f279e5c832fb2ed7c9247ad1541