### PR TITLE
Fix mechanic login data types

### DIFF
--- a/frontend/components/MechanicCard.tsx
+++ b/frontend/components/MechanicCard.tsx
@@ -3,7 +3,7 @@ import { TouchableOpacity, Text, StyleSheet } from 'react-native';
 import { useTheme } from '../hooks';
 
 interface Props {
-  mechanic: { mechanicNumber: number; name: string; role: string };
+  mechanic: { mechanicId: number; name: string; role: string };
   onPress: () => void;
 }
 

--- a/frontend/screens/MechanicSelectScreen.tsx
+++ b/frontend/screens/MechanicSelectScreen.tsx
@@ -56,7 +56,7 @@ export default function MechanicSelectScreen() {
 
       const res = await verifyMechanicLogin({
         companyId: COMPANY_ID,
-        mechanicId: selected, // preserve leading 0s
+        mechanicNumber: parseInt(selected, 10),
         pin,
       });
 


### PR DESCRIPTION
## Summary
- use `mechanicNumber` when verifying login
- update `MechanicCard` prop names

## Testing
- `npx tsc -p frontend/tsconfig.json --noEmit` *(fails: Cannot find module errors)*
- `npx tsc -p backend/tsconfig.json --noEmit` *(fails: Cannot find module errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851986e03d0832fa52fa2eb0f9c5211