### PR TITLE
Improve login PIN UX

### DIFF
--- a/frontend/components/PinModal.tsx
+++ b/frontend/components/PinModal.tsx
@@ -28,6 +28,7 @@ export default function PinModal({ visible, onSubmit, onClose }: Props) {
             value={pin}
             onChangeText={setPin}
             secureTextEntry
+            keyboardType="number-pad"
           />
           <Button title="Submit" onPress={handle} style={styles.button} />
           <Button title="Cancel" onPress={onClose} style={styles.button} />

--- a/frontend/screens/LoginScreen.tsx
+++ b/frontend/screens/LoginScreen.tsx
@@ -47,6 +47,7 @@ export default function LoginScreen() {
         value={pin}
         onChangeText={setPin}
         secureTextEntry
+        keyboardType="number-pad"
       />
       {error && <Text style={styles.error}>{error}</Text>}
       <Button title="Login" onPress={handleSubmit} loading={loading} style={styles.button} />


### PR DESCRIPTION
## Summary
- use numeric keypad for pin entry in modal
- use numeric keypad for pin entry in login screen

## Testing
- `npm run lint` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68519c77e800832f8edd3fcf3430f127