### PR TITLE
Fix login flow to show work orders

### DIFF
--- a/frontend/screens/LoginScreen.tsx
+++ b/frontend/screens/LoginScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useContext } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { TextInput, Button, ThemeToggle, SyncStatusBadge } from '../components';
-import api from '../services/api';
+import { loginMechanic } from '../services/api';
 import { AuthContext } from '../contexts';
 import { useTheme } from '../hooks';
 
@@ -21,9 +21,9 @@ export default function LoginScreen() {
     setError(null);
     setLoading(true);
     try {
-      const response = await api.post('/mechanic/login', { mechanicId, pin });
+      const response = await loginMechanic({ mechanicId: Number(mechanicId) || undefined, pin });
       const { token, mechanicId: id } = response.data;
-      login(id, token);
+      login(String(id), token);
     } catch (err: any) {
       setError('Invalid credentials');
     } finally {

--- a/frontend/screens/MechanicSelectScreen.tsx
+++ b/frontend/screens/MechanicSelectScreen.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react-native';
 import { AuthContext } from '../contexts';
 import { useTheme } from '../hooks';
-import { getMechanics, verifyMechanicLogin } from '../services/api';
+import { getMechanics, loginMechanic } from '../services/api';
 import MechanicCard from '../components/MechanicCard';
 import PinModal from '../components/PinModal';
 
@@ -54,14 +54,13 @@ export default function MechanicSelectScreen() {
         pin,
       });
 
-      const res = await verifyMechanicLogin({
-        companyId: COMPANY_ID,
-        mechanicNumber: parseInt(selected, 10),
+      const res = await loginMechanic({
+        mechanicId: parseInt(selected, 10),
         pin,
       });
 
       console.log('✅ Login success:', res);
-      login(res.mechanicId, res.token);
+      login(String(res.mechanicId), res.token);
     } catch (e) {
       console.error('❌ Login failed:', e);
       setError('Incorrect PIN or login failed.');

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -23,6 +23,11 @@ export async function verifyMechanicLogin(data: {
   return res.data;
 }
 
+export async function loginMechanic(data: { mechanicId?: number; pin?: string }) {
+  const res = await api.post('/auth/login', data);
+  return res.data;
+}
+
 export async function getLineItems(orderId: number) {
   const response = await api.get(`/line-items/${orderId}`);
   return response.data;


### PR DESCRIPTION
## Summary
- support JWT auth from the mechanic selection screen
- use auth login API for manual login

## Testing
- `npx tsc --noEmit` *(fails: tsconfig option errors)*
- `npx eslint .` *(fails: could not find config)*

------
https://chatgpt.com/codex/tasks/task_e_6851a3684540832fa56645a5f8f1d5ae