### PR TITLE
Improve login cancel flow and error handling

### DIFF
--- a/frontend/components/PinModal.tsx
+++ b/frontend/components/PinModal.tsx
@@ -20,7 +20,12 @@ export default function PinModal({ visible, onSubmit, onClose }: Props) {
   };
 
   return (
-    <Modal visible={visible} transparent animationType="fade">
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
       <View style={styles.overlay}>
         <View style={[styles.box, { backgroundColor: theme.background }]}>
           <TextInput

--- a/frontend/screens/InspectionScreen.tsx
+++ b/frontend/screens/InspectionScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useContext } from 'react';
-import { View, FlatList, StyleSheet, ActivityIndicator } from 'react-native';
+import { View, FlatList, StyleSheet, ActivityIndicator, Text } from 'react-native';
 import { RouteProp, useRoute } from '@react-navigation/native';
 import { getLineItems } from '../services/api';
 import { InspectionItemCard, Button, SyncStatusBadge } from '../components';
@@ -18,6 +18,7 @@ export default function InspectionScreen() {
   const order = (route.params as RouteParams).order;
   const [items, setItems] = useState<InspectionItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const { theme } = useTheme();
   const { enqueue } = useContext(SyncContext);
@@ -34,6 +35,7 @@ export default function InspectionScreen() {
         })));
       } catch (e) {
         console.error(e);
+        setError('Failed to load inspection items');
       } finally {
         setLoading(false);
       }
@@ -55,6 +57,14 @@ export default function InspectionScreen() {
     return (
       <View style={[styles.center, { backgroundColor: theme.background }]}>
         <ActivityIndicator size="large" color="#ff00ff" />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={[styles.center, { backgroundColor: theme.background }]}>
+        <Text style={{ color: theme.text }}>{error}</Text>
       </View>
     );
   }

--- a/frontend/screens/LoginScreen.tsx
+++ b/frontend/screens/LoginScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useContext } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
 import { TextInput, Button, ThemeToggle, SyncStatusBadge } from '../components';
 import { loginMechanic } from '../services/api';
 import { AuthContext } from '../contexts';
@@ -8,6 +9,7 @@ import { useTheme } from '../hooks';
 export default function LoginScreen() {
   const { login } = useContext(AuthContext);
   const { theme } = useTheme();
+  const navigation = useNavigation<any>();
   const [mechanicId, setMechanicId] = useState('');
   const [pin, setPin] = useState('');
   const [loading, setLoading] = useState(false);
@@ -50,7 +52,13 @@ export default function LoginScreen() {
         keyboardType="number-pad"
       />
       {error && <Text style={styles.error}>{error}</Text>}
-      <Button title="Login" onPress={handleSubmit} loading={loading} style={styles.button} />
+      <Button
+        title="Login"
+        onPress={handleSubmit}
+        loading={loading}
+        style={styles.button}
+      />
+      <Button title="Cancel" onPress={() => navigation.goBack()} style={styles.button} />
     </View>
   );
 }

--- a/frontend/screens/MechanicSelectScreen.tsx
+++ b/frontend/screens/MechanicSelectScreen.tsx
@@ -285,7 +285,10 @@ export default function MechanicSelectScreen() {
 
         <PinModal
           visible={modal}
-          onClose={() => setModal(false)}
+          onClose={() => {
+            setModal(false);
+            setSelected(null);
+          }}
           onSubmit={handleLogin}
         />
       </View>

--- a/frontend/screens/WorkOrdersScreen.tsx
+++ b/frontend/screens/WorkOrdersScreen.tsx
@@ -25,6 +25,7 @@ export default function WorkOrdersScreen() {
   const { theme } = useTheme();
   const [orders, setOrders] = useState<WorkOrder[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const navigation = useNavigation<any>();
 
   useEffect(() => {
@@ -35,6 +36,7 @@ export default function WorkOrdersScreen() {
         setOrders(data);
       } catch (e) {
         console.error(e);
+        setError('Failed to load work orders');
       } finally {
         setLoading(false);
       }
@@ -54,7 +56,11 @@ export default function WorkOrdersScreen() {
     <View style={[styles.container, { backgroundColor: theme.background }]}>
       <SyncStatusBadge />
       <ThemeToggle />
-      {orders.length === 0 ? (
+      {error ? (
+        <View style={styles.center}>
+          <Text style={[styles.emptyText, { color: theme.text }]}>{error}</Text>
+        </View>
+      ) : orders.length === 0 ? (
         <View style={styles.center}>
           <Text style={[styles.emptyText, { color: theme.text }]}>No work orders assigned</Text>
         </View>


### PR DESCRIPTION
## Summary
- allow cancelling login with Back navigation
- handle Android back press in PinModal
- reset mechanic selection when closing PIN entry
- show friendly error messages for work orders and inspection items

## Testing
- `npx tsc -p frontend/tsconfig.json --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6851acdf5af0832f9fda0d0032662939