### PR TITLE
Fix team member card visibility and clean Axios errors

### DIFF
--- a/frontend/screens/MechanicSelectScreen.tsx
+++ b/frontend/screens/MechanicSelectScreen.tsx
@@ -39,12 +39,12 @@ interface EnhancedMechanicCardProps {
   index: number;
 }
 
-const EnhancedMechanicCard: React.FC<EnhancedMechanicCardProps> = ({ 
-  mechanic, 
-  onPress, 
-  index 
+const EnhancedMechanicCard: React.FC<EnhancedMechanicCardProps> = ({
+  mechanic,
+  onPress,
+  index,
 }) => {
-  const animatedValue = new Animated.Value(0);
+  const animatedValue = React.useRef(new Animated.Value(0)).current;
   
   React.useEffect(() => {
     Animated.timing(animatedValue, {
@@ -578,6 +578,8 @@ const styles = StyleSheet.create({
   mechanicCard: {
     backgroundColor: COLORS.white,
     borderRadius: 16,
+    borderWidth: 1,
+    borderColor: COLORS.lightGray,
     padding: 20,
     flexDirection: 'row',
     alignItems: 'center',

--- a/frontend/screens/WorkOrdersScreen.tsx
+++ b/frontend/screens/WorkOrdersScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { View, FlatList, StyleSheet, ActivityIndicator, Text } from 'react-native';
+import axios from 'axios';
 import { AuthContext } from '../contexts';
 import { useTheme } from '../hooks';
 import { getWorkOrders } from '../services/api';
@@ -34,9 +35,16 @@ export default function WorkOrdersScreen() {
       try {
         const data = await getWorkOrders(mechanicId);
         setOrders(data);
-      } catch (e) {
-        console.error(e);
-        setError('Failed to load work orders');
+        if (Array.isArray(data) && data.length === 0) {
+          setError('No work orders assigned to this mechanic');
+        }
+      } catch (err) {
+        console.error(err);
+        if (axios.isAxiosError(err) && err.response?.status === 404) {
+          setError('No work orders assigned to this mechanic');
+        } else {
+          setError('Failed to load work orders');
+        }
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
## Summary
- keep mechanic card animation state between renders
- add a border so cards are visible
- show friendly text when work orders fetch fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6851bb9403c4832f9b8daa973613d9d7