### PR TITLE
Reload mechanic list when pin entry cancelled

### DIFF
--- a/frontend/screens/MechanicSelectScreen.tsx
+++ b/frontend/screens/MechanicSelectScreen.tsx
@@ -125,21 +125,22 @@ export default function MechanicSelectScreen() {
   const [modal, setModal] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const loadMechanics = async () => {
+    try {
+      console.log('📡 Fetching mechanics for company ID:', COMPANY_ID);
+      const list = await getMechanics(COMPANY_ID);
+      console.log('✅ Mechanics loaded:', list);
+      setMechanics(list);
+    } catch (e) {
+      console.error('❌ Failed to load mechanics:', e);
+      setError('Failed to load mechanics');
+    } finally {
+      setLoading(false);
+    }
+  };
+
   useEffect(() => {
-    const load = async () => {
-      try {
-        console.log('📡 Fetching mechanics for company ID:', COMPANY_ID);
-        const list = await getMechanics(COMPANY_ID);
-        console.log('✅ Mechanics loaded:', list);
-        setMechanics(list);
-      } catch (e) {
-        console.error('❌ Failed to load mechanics:', e);
-        setError('Failed to load mechanics');
-      } finally {
-        setLoading(false);
-      }
-    };
-    load();
+    loadMechanics();
   }, []);
 
   const handleSelect = (id: string) => {
@@ -288,6 +289,7 @@ export default function MechanicSelectScreen() {
           onClose={() => {
             setModal(false);
             setSelected(null);
+            loadMechanics();
           }}
           onSubmit={handleLogin}
         />


### PR DESCRIPTION
## Summary
- ensure mechanic list reloads after closing the PIN dialog

## Testing
- `npx tsc --noEmit`
- `npx tsc --noEmit` in backend

------
https://chatgpt.com/codex/tasks/task_e_6851c8f3f834832fac56bfeaf199b67c