### PR TITLE
Add filtering for active work orders and line items

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -19,3 +19,9 @@ DB_USER=your_user
 DB_PASSWORD=your_password
 DB_PORT=1433
 ```
+
+### Query Filters
+
+When retrieving work orders for a mechanic, the API now excludes orders with a
+status of `4` or `5`. Inspection line items returned for a work order also
+exclude items that have been declined (`DECLINED = '0'`).

--- a/backend/services/inspectionService.ts
+++ b/backend/services/inspectionService.ts
@@ -14,7 +14,7 @@ export async function findLineItems(orderId: number): Promise<LineItem[]> {
     .request()
     .input('OrderID', sql.Int, orderId)
     .query(
-      'SELECT LINE_ITEM_ID, PART_NUMBER, DESCRIPTION FROM LINEITEM WHERE WORK_ORDER_ID = @OrderID'
+      "SELECT LINE_ITEM_ID, PART_NUMBER, DESCRIPTION FROM LINEITEM WHERE WORK_ORDER_ID = @OrderID AND DECLINED = '0'"
     );
 
   return result.recordset.map((row: any) => ({

--- a/backend/services/workOrderService.ts
+++ b/backend/services/workOrderService.ts
@@ -8,7 +8,8 @@ export async function findByTechId(techId: number): Promise<WorkOrder[]> {
     .input('TechID', sql.Int, techId)
     .query(
       `SELECT ESTIMATE_NO, TECH_ID, FIRST_NAME, LAST_NAME, CAR_YEAR, VEH_MAKE, VEH_MODEL, ENGINE_TYPE, LIC_NUMBER, DATE, STATUS
-       FROM ESTMTEHDR WHERE TECH_ID = @TechID`
+       FROM ESTMTEHDR
+       WHERE TECH_ID = @TechID AND STATUS NOT IN (4, 5)`
     );
 
   return result.recordset.map((row: any) => ({

--- a/backend/services/workOrdersService.ts
+++ b/backend/services/workOrdersService.ts
@@ -8,7 +8,8 @@ export async function findByMechanicId(mechanicId: number): Promise<Estimate[]> 
     .input('mechanicId', sql.Int, mechanicId)
     .query(
       `SELECT ESTIMATE_NO, FIRST_NAME, LAST_NAME, CAR_YEAR, MAKE, MODEL, ENGINE_TYPE, LIC_NUMBER, STATUS, DATE
-       FROM ESTMTEHDR WHERE TECH_ID = @mechanicId`
+       FROM ESTMTEHDR
+       WHERE TECH_ID = @mechanicId AND STATUS NOT IN (4, 5)`
     );
 
   return result.recordset.map((row: any) => ({


### PR DESCRIPTION
## Summary
- filter out completed/cancelled work orders in services
- exclude declined line items when loading inspection items
- document new query behaviour

## Testing
- `npx tsc -p backend/tsconfig.json --noEmit`
- `npx tsc -p frontend/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68520da4ce6c832f9152e2186cdae8a4