### PR TITLE
Add auth header to work order requests

### DIFF
--- a/frontend/screens/WorkOrdersScreen.tsx
+++ b/frontend/screens/WorkOrdersScreen.tsx
@@ -22,7 +22,7 @@ interface WorkOrder {
 }
 
 export default function WorkOrdersScreen() {
-  const { mechanicId, logout } = useContext(AuthContext);
+  const { mechanicId, token, logout } = useContext(AuthContext);
   const { theme } = useTheme();
   const [orders, setOrders] = useState<WorkOrder[]>([]);
   const [loading, setLoading] = useState(true);
@@ -34,7 +34,7 @@ export default function WorkOrdersScreen() {
       if (!mechanicId) return;
       try {
         console.log('📡 Fetching work orders for mechanic ID:', mechanicId);
-        const data = await getWorkOrders(mechanicId);
+        const data = await getWorkOrders(mechanicId, token || undefined);
         console.log('✅ Work orders loaded:', data);
         setOrders(data);
         if (Array.isArray(data) && data.length === 0) {
@@ -57,7 +57,7 @@ export default function WorkOrdersScreen() {
       }
     };
     load();
-  }, [mechanicId]);
+  }, [mechanicId, token]);
 
   if (loading) {
     return (

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -4,8 +4,10 @@ const api = axios.create({
   baseURL: process.env.EXPO_PUBLIC_API_URL || 'http://192.168.7.185:3000/api',
 });
 
-export async function getWorkOrders(mechanicId: string) {
-  const response = await api.get(`/work-orders/${mechanicId}`);
+export async function getWorkOrders(mechanicId: string, token?: string) {
+  const response = await api.get(`/work-orders/${mechanicId}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
   return response.data;
 }
 


### PR DESCRIPTION
## Summary
- send JWT token in `getWorkOrders` API call
- pass token from `AuthContext` when loading work orders

## Testing
- `npx tsc --noEmit` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6852173d5934832fa6602639d1da6e24