### PR TITLE
Fix PIN modal keyboard focus

### DIFF
--- a/frontend/components/PinModal.tsx
+++ b/frontend/components/PinModal.tsx
@@ -31,6 +31,7 @@ export default function PinModal({ visible, onSubmit, onClose }: Props) {
       visible={visible}
       transparent
       animationType="fade"
+      onShow={() => inputRef.current?.focus()}
       onRequestClose={onClose}
     >
       <View style={styles.overlay}>


### PR DESCRIPTION
## Summary
- ensure the PIN field focuses when the modal is shown so the keypad pops up automatically

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68522b7ba7ec832f9fdc63b20351454f