### PR TITLE
Add location field and conditional inspection inputs

### DIFF
--- a/backend/models/lineItemModel.ts
+++ b/backend/models/lineItemModel.ts
@@ -2,6 +2,8 @@ export interface LineItem {
   id: number;
   partNumber: string;
   description: string;
+  /** Optional position of the inspected part e.g. "Left Front" */
+  position?: string | null;
   status?: string | null;
   reason?: string | null;
   photo?: string | null;

--- a/backend/services/inspectionService.ts
+++ b/backend/services/inspectionService.ts
@@ -14,13 +14,14 @@ export async function findLineItems(orderId: number): Promise<LineItem[]> {
     .request()
     .input('OrderID', sql.Int, orderId)
     .query(
-      "SELECT LINE_ITEM_ID, PART_NUMBER, DESCRIPTION FROM LINEITEM WHERE WORK_ORDER_ID = @OrderID AND DECLINED = '0'"
+      "SELECT LINE_ITEM_ID, PART_NUMBER, DESCRIPTION, POSITION FROM LINEITEM WHERE WORK_ORDER_ID = @OrderID AND DECLINED = '0'"
     );
 
   return result.recordset.map((row: any) => ({
     id: row.LINE_ITEM_ID,
     partNumber: row.PART_NUMBER,
     description: row.DESCRIPTION,
+    position: row.POSITION || null,
   }));
 }
 

--- a/backend/swagger/swaggerConfig.ts
+++ b/backend/swagger/swaggerConfig.ts
@@ -61,6 +61,7 @@ const options: swaggerJSDoc.Options = {
             id: { type: 'number' },
             partNumber: { type: 'string' },
             description: { type: 'string' },
+            position: { type: 'string', nullable: true },
             status: { type: 'string', nullable: true },
             reason: { type: 'string', nullable: true },
             photo: { type: 'string', nullable: true },

--- a/frontend/components/InspectionItemCard.tsx
+++ b/frontend/components/InspectionItemCard.tsx
@@ -9,6 +9,7 @@ export interface InspectionItem {
   id: number;
   partNumber: string;
   description: string;
+  position?: string | null;
   status?: Status | null;
   reason?: string;
   photo?: string;
@@ -39,13 +40,23 @@ export default function InspectionItemCard({ item, onChange }: Props) {
     <Animated.View style={[styles.card, { transform: [{ translateX: slideAnim }], backgroundColor: theme.background }]}>
       <Text style={[styles.title, { color: theme.text }]}>{item.partNumber}</Text>
       <Text style={[styles.desc, { color: theme.text }]}>{item.description}</Text>
+      {item.position && (
+        <Text style={[styles.position, { color: theme.text }]}>{item.position}</Text>
+      )}
       <StatusSelector value={item.status || null} onChange={(s) => update({ status: s })} />
-      <TextInput
-        placeholder="Reason (optional)"
-        value={item.reason}
-        onChangeText={(t) => update({ reason: t })}
-      />
-      <PhotoUploader value={item.photo} onChange={(uri) => update({ photo: uri })} />
+      {(item.status === 'yellow' || item.status === 'red') && (
+        <>
+          <TextInput
+            placeholder="Reason"
+            value={item.reason}
+            onChangeText={(t) => update({ reason: t })}
+          />
+          <PhotoUploader
+            value={item.photo}
+            onChange={(uri) => update({ photo: uri })}
+          />
+        </>
+      )}
     </Animated.View>
   );
 }
@@ -63,5 +74,9 @@ const styles = StyleSheet.create({
   },
   desc: {
     marginBottom: 8,
+  },
+  position: {
+    marginBottom: 8,
+    fontStyle: 'italic',
   },
 });

--- a/frontend/screens/InspectionScreen.tsx
+++ b/frontend/screens/InspectionScreen.tsx
@@ -31,6 +31,7 @@ export default function InspectionScreen() {
           id: it.id || idx,
           partNumber: it.PART_NUMBER || it.partNumber,
           description: it.DESCRIPTION || it.description,
+          position: it.POSITION || it.position || null,
           status: null,
         })));
       } catch (e) {

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -36,7 +36,7 @@ export async function getLineItems(orderId: number) {
 }
 
 export async function submitInspection(data: any) {
-  const response = await api.post('/inspections', data);
+  const response = await api.post('/inspections/submit', data);
   return response.data;
 }
 


### PR DESCRIPTION
## Summary
- support optional `position`/`location` field for inspection line items
- show position in inspection cards
- require reason and photo only when status is yellow or red
- adjust API path to submit inspections

## Testing
- `npx tsc --noEmit` in `frontend`
- `npx tsc --noEmit` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68522d552ee0832fa4eaeca072604bb8